### PR TITLE
fix(extension): cross-origin nav must update daemon's lastActiveTab — §2C(iv)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -370,6 +370,23 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
           // (§2C(iii)) → open new background tab, never clobber.
           const tab = await chrome.tabs.create({ url: params.url, active: false })
           tabId = tab.id
+          // §2C(iv) [2026-05-09 post-merge dogfood fix] — chrome.tabs.create
+          // with active:false does NOT trigger chrome.tabs.onActivated, so
+          // the existing active_tab_changed notification (line ~1430) never
+          // fires. Daemon's lastActiveTab cache stays pointing at the OLD
+          // active tab, and subsequent ops in the same plan (eval/extract)
+          // silently route to the wrong page. Manually emit the
+          // notification here so the cache catches up. Gated on fromDaemon
+          // so popup path (user-driven) doesn't override daemon cache.
+          if (fromDaemon && ws && ws.readyState === WebSocket.OPEN) {
+            try {
+              ws.send(JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'active_tab_changed',
+                params: { tabId, url: params.url },
+              }))
+            } catch { /* socket gone */ }
+          }
         } else {
           // Same-origin SPA-style nav: cheap tabs.update.
           await chrome.tabs.update(tabId, { url: params.url })

--- a/extension/test/self-heal.test.mjs
+++ b/extension/test/self-heal.test.mjs
@@ -203,6 +203,78 @@ test("origin mismatch branch opens new tab via chrome.tabs.create", () => {
 });
 
 // ═══════════════════════════════════════════════════════════
+// Rule (iv): cross-origin new tab must update daemon's lastActiveTab cache
+// Why: 2026-05-08 dogfood post-merge — after §2C(iii) opens a new bg tab
+// for cross-origin nav, subsequent ops in the same plan got routed to
+// the OLD active tab (silent data corruption again, just at a different
+// layer). Root cause: chrome.tabs.create({active:false}) doesn't trigger
+// chrome.tabs.onActivated, so the existing `active_tab_changed` listener
+// at line ~1430 never fires. Daemon's lastActiveTab cache stays stale.
+// Fix: after creating the new bg tab in the §2C(iii) cross-origin branch,
+// the extension must MANUALLY emit `active_tab_changed` to daemon so the
+// cache points at the new tab. Subsequent ops without explicit tabId/
+// sessionId then route correctly via the lastActiveTab fallback.
+// ═══════════════════════════════════════════════════════════
+
+console.log("\n  -- Rule (iv): cross-origin new tab notifies daemon --\n");
+
+test("cross-origin/isInternal nav branch sends active_tab_changed", () => {
+  // The branch that calls chrome.tabs.create for cross-origin or
+  // isInternal must, before returning, send active_tab_changed via ws
+  // with the new tab's id. Otherwise daemon-side lastActiveTab cache
+  // keeps pointing at the previous active tab, and subsequent ops
+  // (eval/extract/click) silently target the wrong page.
+  const navStart = BG_SRC.indexOf("case 'nav':");
+  const navBlock = BG_SRC.slice(navStart, navStart + 4000);
+  // Pattern: within or right after chrome.tabs.create call, must have
+  // an ws.send referencing 'active_tab_changed'.
+  // Looser proxy: after `chrome.tabs.create` (within ~600 chars) there
+  // must be `active_tab_changed` referenced.
+  const createMatches = [...navBlock.matchAll(/chrome\.tabs\.create/g)];
+  let foundAfterCreate = false;
+  for (const m of createMatches) {
+    const after = navBlock.slice(m.index, m.index + 800);
+    if (/active_tab_changed/.test(after)) {
+      foundAfterCreate = true;
+      break;
+    }
+  }
+  assert(
+    foundAfterCreate,
+    "After `chrome.tabs.create` in nav handler, must emit `active_tab_changed` " +
+      "to daemon so lastActiveTab cache updates. Otherwise subsequent ops " +
+      "in the same plan route to the OLD active tab (silent tab routing).",
+  );
+});
+
+test("active_tab_changed emit is gated on fromDaemon (popup path unaffected)", () => {
+  // The new emit must only fire when fromDaemon=true, so popup path
+  // (user-initiated) doesn't spuriously update daemon cache.
+  // Looser proxy: somewhere in the nav handler, an `if (fromDaemon ...)`
+  // guard exists with `active_tab_changed` in its body block (within
+  // ~500 chars after the if).
+  const navStart = BG_SRC.indexOf("case 'nav':");
+  const navBlock = BG_SRC.slice(navStart, navStart + 4000);
+  // Find any `if (fromDaemon ...)` whose body block (next ~500 chars)
+  // includes active_tab_changed.
+  const ifFromDaemonRe = /if\s*\(\s*fromDaemon[^)]*\)\s*\{/g;
+  let foundGated = false;
+  for (const m of navBlock.matchAll(ifFromDaemonRe)) {
+    const body = navBlock.slice(m.index, m.index + 600);
+    if (/active_tab_changed/.test(body)) {
+      foundGated = true;
+      break;
+    }
+  }
+  assert(
+    foundGated,
+    "active_tab_changed emit in nav handler must be inside an " +
+      "`if (fromDaemon ...)` guard (otherwise popup-driven navs would " +
+      "override daemon cache).",
+  );
+});
+
+// ═══════════════════════════════════════════════════════════
 
 console.log(`\n  ${passed} passed, ${failed} failed`);
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary

**CDD Phase 7 post-merge fix.** §2C(iii) shipped in PR #5 opens a new bg tab for cross-origin nav, but `chrome.tabs.create({active:false})` doesn't trigger `chrome.tabs.onActivated`, so the daemon's `lastActiveTab` cache stays stale. Subsequent ops in the same plan silently route to the OLD active tab.

## Symptom

Real dogfood 2026-05-09 (after merging PR #5):

```
Plan A: ahrefs/taprun_wa  → tab 1692089668 (Ahrefs)
Plan B: cursor/taprun_check (cross-origin)
  - nav opens new tab 1692089671 (cursor.directory) ✓ (§2C(iii) worked)
  - eval result: bodyText, title, url all from tab 1692089668 (Ahrefs!) ✗
```

The page object correctly shows the new cursor tab, but the eval result was injected into the OLD Ahrefs tab.

## Root cause

`active_tab_changed` is sent via `chrome.tabs.onActivated` listener (line ~1430). When `chrome.tabs.create({active:false})` is used, the new tab is NOT activated, so onActivated doesn't fire, and daemon's `lastActiveTab` stays at the previous tab.

The existing `lastActiveTab` fallback at line ~1364 then routes the next op to the OLD tab.

## Fix

In the §2C(ii)/(iii) `chrome.tabs.create` branch, manually emit `active_tab_changed` to ws when `fromDaemon=true`. Daemon's cache catches up; subsequent ops route correctly.

```js
if (isInternal || crossOrigin) {
  const tab = await chrome.tabs.create({ url: params.url, active: false })
  tabId = tab.id
  // §2C(iv) post-merge fix
  if (fromDaemon && ws && ws.readyState === WebSocket.OPEN) {
    ws.send(JSON.stringify({
      jsonrpc: '2.0',
      method: 'active_tab_changed',
      params: { tabId, url: params.url },
    }))
  }
}
```

## Static guards (Rule iv in `self-heal.test.mjs`)

- iv/1: `chrome.tabs.create` branch sends `active_tab_changed`
- iv/2: emit is gated on `fromDaemon` (popup path unaffected)

## CDD verification

- **RED** (post-mortem of merged PR #5): 1 fail (Rule iv/1 — emit absent)
- **GREEN**: 10/10 (8 from §2C i+ii+iii + 2 new for §2C iv)
- **Regression**: architecture (17/17) + protocol (32/32) + multi-tab (15/15) + self-heal (10/10) + tap-format + wire_codes — no regressions

## Phase 7 learning

Source-text tests verified the STATIC shape (new tab created on cross-origin) but couldn't verify the DYNAMIC tab routing across daemon-driven multi-op plans. **Real dogfood exposed the gap between "new tab opened" and "subsequent ops route to it"**. Rule (iv) closes the static guard at the same layer (source-text proxy for the runtime behavior). Per CDD v3 §7: the new RED test was added BEFORE the implementation fix, then the audit note explains why the original §2C(iii) tests passed despite this gap.

## Real-world verification

After merge + reload extension:
1. Re-run cursor/taprun_check immediately after ahrefs/taprun_wa
2. Eval result should contain cursor.directory content (NOT Ahrefs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)