### PR TITLE
docs(robots): disallow /cdn-cgi/ (clears Ahrefs email-protection 404 errors)

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /cdn-cgi/
 
 Sitemap: https://taprun.dev/sitemap.xml


### PR DESCRIPTION
## What

Adds `Disallow: /cdn-cgi/` to `docs/robots.txt`.

## Why

Ahrefs Site Audit reported ~18 "errors" for taprun.dev. A full self-crawl of all 268 internal URLs showed the site is HTTP-clean (266/268 → 200); the only 404 is `/cdn-cgi/l/email-protection`, injected by **Cloudflare Email Address Obfuscation** rewriting `hello@/support@taprun.dev`. Crawlers strip the `#fragment` and hit the bare URL (404), counted across 14 pages × utm/`.html` variants ≈ 18 errors. Real users are unaffected (Cloudflare's JS restores the mailto on click) — these are SEO phantom errors.

## Fix

- **Root cause** already fixed out-of-band: `email_obfuscation` zone setting set to `off` (verified — live HTML now serves 0 `/cdn-cgi/` links, real `mailto:` restored).
- **This PR**: `Disallow: /cdn-cgi/` is standard hygiene — everything under `/cdn-cgi/` is Cloudflare-internal and shouldn't be crawled regardless.

Merge to deploy via GitHub Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)