### PR TITLE
Harden op:input + native-dialog handling for modern SPA editors (weixin dogfood)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -147,10 +147,20 @@ async function ensureDebugger(tabId) {
   } catch (e) {
     if (e.message?.includes('Already attached')) {
       debuggerSessions.set(tabId, { ...debuggerSessions.get(tabId), attached: true })
+      await enablePageDomain(tabId)
       return
     }
     throw e
   }
+  // Enable the Page domain so Page.javascriptDialogOpening is delivered to
+  // handleDialogEvent — native dialogs fired mid-op are auto-handled instead of
+  // hanging the op ~3.5min (2026-06-11 weixin dogfood). Best-effort: a failure
+  // here must not break the attach the caller actually needs.
+  await enablePageDomain(tabId)
+}
+
+async function enablePageDomain(tabId) {
+  try { await chrome.debugger.sendCommand({ tabId }, 'Page.enable') } catch { /* benign */ }
 }
 
 async function withDebugger(tabId, fn) {
@@ -274,6 +284,27 @@ async function execFunc(t, func, ...args) {
     target, func, args, world: 'MAIN'
   })
   return result?.result
+}
+
+// Suppress the native beforeunload "Leave site?" dialog before we reload/navigate
+// an existing tab. A dirty page (unsaved form) otherwise pops a native dialog that
+// BLOCKS the navigation — and native dialogs aren't page DOM, so nothing in the op
+// set can dismiss them and the relay just waits (2026-06-11 weixin self-menu dogfood:
+// op:nav hung ~3.5 min on a dirty editor). onbeforeunload=null only covers the
+// `window.onbeforeunload = fn` style; modern pages (WeChat mp) guard via
+// addEventListener('beforeunload'), so we also add a CAPTURING listener that runs
+// before the page handler, stops propagation, and clears returnValue (a non-empty
+// returnValue is what fires the dialog). Best-effort — never block nav on failure.
+async function neutralizeBeforeUnload(tabId) {
+  const suppressBeforeUnload = () => {
+    window.onbeforeunload = null
+    window.addEventListener('beforeunload', (e) => {
+      e.stopImmediatePropagation()
+      e.preventDefault()
+      try { e.returnValue = undefined } catch (_) {}
+    }, { capture: true })
+  }
+  try { await execFunc(tabId, suppressBeforeUnload) } catch (_) { /* best-effort */ }
 }
 
 // #62 frame-piercing combinator: "<iframe-sel> >>> <inner-sel>" addresses an
@@ -532,6 +563,9 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
           createdByNav = true
         } else {
           // Same-origin SPA-style nav: cheap tabs.update (not createdByNav).
+          // Neutralize beforeunload first so a dirty page's "Leave site?" native
+          // dialog can't block the nav and hang the relay (2026-06-11 dogfood).
+          await neutralizeBeforeUnload(tabId)
           await chrome.tabs.update(tabId, { url: params.url })
         }
       }
@@ -705,8 +739,25 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
     case 'click': {
       const { t: fx, sel: target, dx, dy } = await resolveFrame(tabId, params.target || params.selector)
       // JS-first: use el.click() via execFunc — no debugger, no yellow bar, CSP-immune
-      const result = await execFunc(fx, (t) => {
+      // Named + self-contained so it injects via execFunc AND is extractable by
+      // test/visible-click.test.mjs (background.js isn't node-importable — chrome.*).
+      const clickResolver = (t) => {
+        // Prefer the first VISIBLE match. document.querySelector returns the first
+        // DOM match even if display:none/hidden — which clicked a hidden "退出登录"
+        // sharing .weui-desktop-btn_primary in the 2026-06-11 weixin self-menu
+        // dogfood and logged the session out. Below-fold (scrolled) elements keep
+        // size>0 so they still resolve; only display:none/hidden/zero-box are skipped.
+        const vis = (e) => {
+          if (!e) return false
+          const s = (typeof getComputedStyle === 'function') ? getComputedStyle(e) : null
+          if (s && (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0')) return false
+          const r = e.getBoundingClientRect()
+          return r.width > 0 && r.height > 0
+        }
         let el = document.querySelector(t)
+        if (el && !vis(el)) {
+          for (const e of document.querySelectorAll(t)) { if (vis(e)) { el = e; break } }
+        }
         if (!el) {
           for (const e of document.querySelectorAll('a, button, [role="button"], input, [onclick], [tabindex]')) {
             if ((e.textContent?.trim().toLowerCase().includes(t.toLowerCase())) ||
@@ -724,7 +775,8 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
         el.click()
         const r = el.getBoundingClientRect()
         return { clicked: true, x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }
-      }, target)
+      }
+      const result = await execFunc(fx, clickResolver, target)
       if (!result) throw new Error('selector_not_found: ' + target + ' (page not ready — exec returned null)')
       // CDP fallback: if site needs isTrusted events, retry with cdpClick
       // (dx/dy translate frame-relative coords to top-frame viewport space)
@@ -787,6 +839,29 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
         await cdpClick(tabId, probe.x + dx, probe.y + dy)
         await handleMethod('keyboard', { tabId, key: 'a', action: 'press', modifiers: 4 })
         await handleMethod('keyboard', { tabId, key: text, action: 'type' })
+        // issue #19's lesson, generalized: per-char dispatchKeyEvent({text}) silently
+        // no-ops on some framework editors (weixin `.emotion_editor`, 2026-06-11
+        // dogfood) — and UNLIKE the contenteditable path this branch had NO
+        // post-verify, so zero-effect typing returned success (6 attempts chasing a
+        // silent no-op). Verify the text landed, GATED to editor contexts so the
+        // key-LISTENER widgets this path exists for never false-fail.
+        const keysLanded = (s, want) => {
+          const el = document.querySelector(s)
+          if (!el) return { found: false, editorish: false, has: false }
+          const editorish = !!el.isContentEditable
+            || !!(el.querySelector && el.querySelector('[contenteditable=""],[contenteditable=true]'))
+            || !!(el.closest && el.closest('[contenteditable=""],[contenteditable=true]'))
+          const txt = (el.innerText || el.textContent || '')
+          const w = String(want == null ? '' : want).replace(/\s+/g, '')
+          return { found: true, editorish, has: w ? txt.replace(/\s+/g, '').includes(w) : true }
+        }
+        const chk = await execFunc(fx, keysLanded, selector, text)
+        if (chk && chk.found && chk.editorish && !chk.has) {
+          throw new Error(
+            'input_ineffective: per-char keystrokes did not land in editor ' + selector +
+            ' — the editor rejected synthesized key events; try op:input kind=setHtml, or capture the write API and replay via op:fetch'
+          )
+        }
       }
       return {}
     }
@@ -864,10 +939,17 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
       await withDebugger(tabId, () =>
         chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text: String(params.text ?? '') }))
       // Verify it landed (issue #19: no error, no effect) — re-read the control.
-      const got = await execFunc(fx, (s) => {
+      // contenteditable has no .value — read innerText/textContent there, else .value.
+      // (2026-06-11 weixin dogfood: keytype into a contenteditable .edit_area threw a
+      // false "value did not land (len 0)" because the verify-read used .value on a
+      // <div>.) Named + self-contained so it injects AND is extractable by
+      // test/keytype-verify.test.mjs.
+      const readControlValue = (s) => {
         const el = document.querySelector(s)
-        return el ? (el.value || '') : null
-      }, sel)
+        if (!el) return null
+        return el.isContentEditable ? (el.innerText || el.textContent || '') : (el.value || '')
+      }
+      const got = await execFunc(fx, readControlValue, sel)
       if ((got || '').replace(/\s+/g, '') !== String(params.text ?? '').replace(/\s+/g, '')) {
         throw new Error(`keytype: value did not land for selector: ${sel} (got len ${(got || '').length})`)
       }
@@ -1665,6 +1747,24 @@ const KEY_MAP = {
 //
 // Don't defer CDP work to a separate command. Capture eagerly inside the
 // listener, store on the entry / in requestMeta, let networkDump just read.
+
+// RC4 (2026-06-11 weixin dogfood): native JS dialogs (alert/confirm/prompt/
+// beforeunload) are NOT page DOM — no op can dismiss them, so an unhandled one
+// hangs the op until the relay socket times out (~3.5min on the dirty self-menu
+// editor's "Leave site?"). With the Page domain enabled on every debugger attach
+// (ensureDebugger), auto-handle them at the CDP layer. Policy: ACCEPT
+// beforeunload (we navigate on purpose → leave) + alert (informational); DISMISS
+// confirm + prompt (cancel is the safe default — never auto-confirm a
+// destructive "确定删除?" the agent did not intend). Complements P0b, which
+// suppresses the beforeunload on the nav path (no debugger attached there).
+async function handleDialogEvent(source, method, params) {
+  if (method !== 'Page.javascriptDialogOpening') return
+  const accept = params?.type === 'beforeunload' || params?.type === 'alert'
+  try {
+    await chrome.debugger.sendCommand({ tabId: source.tabId }, 'Page.handleJavaScriptDialog', { accept })
+  } catch { /* dialog already gone (navigation / debugger detach) */ }
+}
+chrome.debugger.onEvent.addListener(handleDialogEvent)
 
 chrome.debugger.onEvent.addListener((source, method, params) => {
   const tabId = source.tabId

--- a/extension/background.js
+++ b/extension/background.js
@@ -201,17 +201,31 @@ async function typeIntoContentEditable(tabId, fx, selector, text, coords) {
   // select-all-then-type intent of the original `type` fallback). On an empty
   // editor this selects nothing and insertText just inserts at the caret.
   await handleMethod('keyboard', { tabId, key: 'a', action: 'press', modifiers: 4 })
-  // RC1 (2026-06-12 weixin dogfood): some rich editors commit their MODEL only on
-  // the trusted IME composition pipeline (compositionstart/update/end), NOT on the
-  // `input` event a bare insertText fires — WeChat's msg-sender `.edit_area` kept an
-  // EMPTY model (确定 → "内容不能为空") though insertText filled the DOM, and
-  // op:input press (dispatchKeyEvent) / blur / op:eval-dispatch (lint-forbidden) all
-  // failed to commit it. imeSetComposition emits compositionstart/update; the
-  // following insertText commits (compositionend + input) — the exact trusted
-  // sequence a Chinese IME produces. insertText stays the commit step, so
-  // composition-agnostic editors (Quill, ProseMirror — issue #19) are unaffected.
+  // Editor-aware composition (2026-06-12 weixin dogfood). Two kinds of
+  // contenteditable need OPPOSITE handling:
+  //  - Rich editors that manage their own input and handle Input.insertText
+  //    natively (ProseMirror, Quill — issue #19 — CodeMirror) DOUBLE-insert if we
+  //    also drive an IME composition (imeSetComposition replaces the selection AND
+  //    the committing insertText adds a second copy: 被关注 ProseMirror → 2×). For
+  //    these, plain select-all + insertText replaces in a single copy.
+  //  - Custom contenteditables that commit their MODEL only on compositionend
+  //    (WeChat msg-sender `.edit_area`: insertText filled the DOM but 确定 saw an
+  //    EMPTY model; press/blur/op:eval-dispatch all failed) NEED the trusted IME
+  //    pipeline imeSetComposition (compositionstart/update) → insertText (commit:
+  //    compositionend + input).
+  // So composition is opt-IN for editors we don't recognise as native-insert.
+  const nativeInsertEditor = await execFunc(fx, (sel) => {
+    const el = document.querySelector(sel)
+    if (!el) return false
+    return !!(el.closest && el.closest('.ProseMirror, .ql-editor, .CodeMirror, .cm-editor')) ||
+      !!(el.classList && (el.classList.contains('ProseMirror') || el.classList.contains('ql-editor')))
+  }, selector)
   await withDebugger(tabId, async () => {
-    if (text) {
+    if (text && !nativeInsertEditor) {
+      // imeSetComposition composes at the caret and does NOT clear an active
+      // selection, so delete the select-all'd content first (insertText '' replaces
+      // the selection with nothing) or the composition APPENDS to it (2026-06-12).
+      await chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text: '' })
       try {
         await chrome.debugger.sendCommand({ tabId }, 'Input.imeSetComposition', {
           text, selectionStart: text.length, selectionEnd: text.length,

--- a/extension/background.js
+++ b/extension/background.js
@@ -201,8 +201,25 @@ async function typeIntoContentEditable(tabId, fx, selector, text, coords) {
   // select-all-then-type intent of the original `type` fallback). On an empty
   // editor this selects nothing and insertText just inserts at the caret.
   await handleMethod('keyboard', { tabId, key: 'a', action: 'press', modifiers: 4 })
-  await withDebugger(tabId, () =>
-    chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text }))
+  // RC1 (2026-06-12 weixin dogfood): some rich editors commit their MODEL only on
+  // the trusted IME composition pipeline (compositionstart/update/end), NOT on the
+  // `input` event a bare insertText fires — WeChat's msg-sender `.edit_area` kept an
+  // EMPTY model (确定 → "内容不能为空") though insertText filled the DOM, and
+  // op:input press (dispatchKeyEvent) / blur / op:eval-dispatch (lint-forbidden) all
+  // failed to commit it. imeSetComposition emits compositionstart/update; the
+  // following insertText commits (compositionend + input) — the exact trusted
+  // sequence a Chinese IME produces. insertText stays the commit step, so
+  // composition-agnostic editors (Quill, ProseMirror — issue #19) are unaffected.
+  await withDebugger(tabId, async () => {
+    if (text) {
+      try {
+        await chrome.debugger.sendCommand({ tabId }, 'Input.imeSetComposition', {
+          text, selectionStart: text.length, selectionEnd: text.length,
+        })
+      } catch (_) { /* composition unsupported/refused — insertText below still commits */ }
+    }
+    await chrome.debugger.sendCommand({ tabId }, 'Input.insertText', { text })
+  })
   // Verify the mutation took effect (issue #19: no error, no effect). Compare
   // whitespace-stripped so rich-text wrapping (<p>/<br>) and newline
   // normalization don't trigger a false failure.
@@ -299,9 +316,15 @@ async function neutralizeBeforeUnload(tabId) {
   const suppressBeforeUnload = () => {
     window.onbeforeunload = null
     window.addEventListener('beforeunload', (e) => {
+      // Stop the page's own guard (the common addEventListener('beforeunload')
+      // case) from running, and force returnValue empty so no dialog fires.
+      // CRITICAL: do NOT call e.preventDefault() — on a beforeunload event that
+      // REQUESTS the dialog (HTML spec), so calling it here made this suppressor
+      // pop the very "Leave site?" it exists to kill (2026-06-12 dogfood: dirty
+      // reload still hung ~3.5min). stopImmediatePropagation + returnValue=''
+      // is the correct suppression.
       e.stopImmediatePropagation()
-      e.preventDefault()
-      try { e.returnValue = undefined } catch (_) {}
+      e.returnValue = ''
     }, { capture: true })
   }
   try { await execFunc(tabId, suppressBeforeUnload) } catch (_) { /* best-effort */ }

--- a/extension/test/beforeunload-suppress.test.mjs
+++ b/extension/test/beforeunload-suppress.test.mjs
@@ -72,11 +72,15 @@ test('suppressor nulls onbeforeunload AND adds a capturing listener that suppres
   const cap = bu.find(l => l.opts === true || (l.opts && l.opts.capture === true))
   assert(cap, 'beforeunload listener must be capturing (runs before the page handler)')
   // invoke it with a returnValue-setting event; assert the dialog trigger is neutralized
-  let stopped = false
-  const ev = { returnValue: 'You have unsaved changes', preventDefault() {}, stopImmediatePropagation() { stopped = true } }
+  let stopped = false, prevented = false
+  const ev = { returnValue: 'You have unsaved changes', preventDefault() { prevented = true }, stopImmediatePropagation() { stopped = true } }
   cap.fn(ev)
   assert(stopped, 'must stopImmediatePropagation so the page beforeunload handler never runs')
   assert(!ev.returnValue, `must clear returnValue (non-empty returnValue is what fires the dialog), got ${JSON.stringify(ev.returnValue)}`)
+  // Adversarial: calling preventDefault() on beforeunload REQUESTS the dialog
+  // (HTML spec) — the suppressor must NOT call it, or it pops the very dialog it
+  // exists to kill (2026-06-12 dogfood: dirty reload hung ~3.5min on exactly this).
+  assert(!prevented, 'suppressor must NOT call preventDefault() — that REQUESTS the beforeunload dialog')
 })
 
 console.log(`\n  ${passed} passed, ${failed} failed\n`)

--- a/extension/test/beforeunload-suppress.test.mjs
+++ b/extension/test/beforeunload-suppress.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Constraint: before op:nav reloads/navigates an EXISTING tab, the extension
+ * neutralizes beforeunload so a dirty page's native "Leave site?" dialog cannot
+ * block the navigation.
+ * Classification: safety / what — 2026-06-11 weixin dogfood: a dirty self-menu
+ *   editor's beforeunload dialog hung op:nav ~3.5 min (native dialogs aren't page
+ *   DOM; nothing in the op set can dismiss them, so the relay just waited).
+ *
+ * Behavioral (extract-and-run): the injected suppressor fn is pulled from
+ * background.js source and executed against a fake window. The suppressor MUST
+ * (a) null window.onbeforeunload AND (b) register a capturing beforeunload
+ * listener that stopImmediatePropagation + clears returnValue (the page's
+ * addEventListener('beforeunload') handler — the common modern case — is what
+ * onbeforeunload=null alone misses).
+ *
+ * Phase 1a (adversarial): a half-impl that only does `window.onbeforeunload =
+ * null` (today's `case 'dialog'` behavior) passes a grep for "beforeunload" but
+ * leaves addEventListener-based handlers firing the dialog. This RUNS the
+ * suppressor and invokes the registered listener with a returnValue-setting
+ * event — the onbeforeunload-only impl registers no listener and fails.
+ *
+ * Phase 1b (anchor): WeChat mp's editor guards unsaved changes via
+ * addEventListener('beforeunload') (the "Leave site?" seen 2026-06-11), not a
+ * window.onbeforeunload assignment.
+ *
+ * Run: node extension/test/beforeunload-suppress.test.mjs
+ */
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+let passed = 0, failed = 0
+const test = (n, f) => { try { f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${n}`) } catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${n}\n    ${e.message}`) } }
+
+function extractSuppressor(src) {
+  const marker = 'const suppressBeforeUnload = '
+  const start = src.indexOf(marker)
+  if (start === -1) throw new Error('suppressBeforeUnload not found — op:nav must neutralize beforeunload via a named `const suppressBeforeUnload = () => {…}` before navigating an existing tab')
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start))
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) { const c = src[i]; if (c === '{') depth++; else if (c === '}') { depth--; if (!depth) { i++; break } } }
+  return src.slice(src.indexOf('()', start), i)
+}
+
+const src = (() => { try { return extractSuppressor(BG) } catch { return null } })()
+
+console.log('\n  -- op:nav neutralizes beforeunload before navigating an existing tab --\n')
+
+test('suppressBeforeUnload exists as a named injected fn', () => assert(src, 'background.js must define `const suppressBeforeUnload = () => {…}`'))
+
+test('nav handler calls neutralize before the same-origin tabs.update', () => {
+  // structural backstop: the suppressor must actually be wired into the nav path
+  const navStart = BG.indexOf("case 'nav': {")
+  const navRegion = BG.slice(navStart, navStart + 4000)
+  const updIdx = navRegion.indexOf('chrome.tabs.update(tabId, { url: params.url })')
+  assert(updIdx !== -1, 'same-origin tabs.update line present')
+  const neutIdx = navRegion.indexOf('neutralizeBeforeUnload(')
+  assert(neutIdx !== -1 && neutIdx < updIdx, 'neutralizeBeforeUnload(tabId) must run BEFORE the same-origin tabs.update')
+})
+
+test('suppressor nulls onbeforeunload AND adds a capturing listener that suppresses the dialog', () => {
+  assert(src, 'suppressor missing')
+  const listeners = []
+  const fakeWindow = {
+    onbeforeunload: function pageGuard() { },
+    addEventListener(type, fn, opts) { listeners.push({ type, fn, opts }) },
+  }
+  new Function('window', `(${src})()`)(fakeWindow)
+  assert.equal(fakeWindow.onbeforeunload, null, 'must null window.onbeforeunload')
+  const bu = listeners.filter(l => l.type === 'beforeunload')
+  assert(bu.length >= 1, 'must register a beforeunload listener (covers addEventListener-based page guards)')
+  const cap = bu.find(l => l.opts === true || (l.opts && l.opts.capture === true))
+  assert(cap, 'beforeunload listener must be capturing (runs before the page handler)')
+  // invoke it with a returnValue-setting event; assert the dialog trigger is neutralized
+  let stopped = false
+  const ev = { returnValue: 'You have unsaved changes', preventDefault() {}, stopImmediatePropagation() { stopped = true } }
+  cap.fn(ev)
+  assert(stopped, 'must stopImmediatePropagation so the page beforeunload handler never runs')
+  assert(!ev.returnValue, `must clear returnValue (non-empty returnValue is what fires the dialog), got ${JSON.stringify(ev.returnValue)}`)
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)

--- a/extension/test/contenteditable-input.test.mjs
+++ b/extension/test/contenteditable-input.test.mjs
@@ -61,7 +61,7 @@ test('typeIntoContentEditable helper exists', () => {
 })
 
 {
-  const helper = BG_SRC.substring(helperStart, helperStart + 2600) // widened for the RC1 IME-composition pipeline (2026-06-12)
+  const helper = BG_SRC.substring(helperStart, helperStart + 3200) // widened for the RC1 IME-composition pipeline + clear-selection (2026-06-12)
 
   test('helper uses CDP Input.insertText (not per-char dispatchKeyEvent)', () => {
     assert(helper.includes("'Input.insertText'") || helper.includes('"Input.insertText"'),

--- a/extension/test/contenteditable-input.test.mjs
+++ b/extension/test/contenteditable-input.test.mjs
@@ -61,7 +61,7 @@ test('typeIntoContentEditable helper exists', () => {
 })
 
 {
-  const helper = BG_SRC.substring(helperStart, helperStart + 1800)
+  const helper = BG_SRC.substring(helperStart, helperStart + 2600) // widened for the RC1 IME-composition pipeline (2026-06-12)
 
   test('helper uses CDP Input.insertText (not per-char dispatchKeyEvent)', () => {
     assert(helper.includes("'Input.insertText'") || helper.includes('"Input.insertText"'),

--- a/extension/test/dialog-autohandle.test.mjs
+++ b/extension/test/dialog-autohandle.test.mjs
@@ -1,0 +1,88 @@
+/**
+ * Constraint: native JS dialogs (alert/confirm/prompt/beforeunload) are
+ * auto-handled at the CDP layer so they can never hang an op.
+ * Classification: safety / what — 2026-06-11 weixin dogfood: a native "Leave
+ *   site?" dialog hung op:nav ~3.5min until the relay socket timed out. Native
+ *   dialogs are NOT page DOM — no op can dismiss them. P0b suppresses the
+ *   beforeunload on the nav path via page injection; this is the GENERAL defense
+ *   for the whole dialog class on any debugger-attached op (a confirm()/alert()
+ *   fired mid-op would otherwise still hang with no page-side suppressor).
+ *
+ * Policy (safe-by-default): ACCEPT beforeunload (we navigate on purpose → leave)
+ * and alert (informational, nothing to confirm); DISMISS confirm + prompt
+ * (cancel — NEVER auto-confirm a destructive "确定删除?" the agent didn't intend).
+ *
+ * Behavioral (extract-and-run): the named handler `async function
+ * handleDialogEvent` is pulled from background.js and executed against a
+ * chrome.debugger.sendCommand spy.
+ *
+ * Phase 1a (adversarial): a half-impl that accepts ALL dialogs (or dismisses all)
+ * passes a grep for handleJavaScriptDialog but is unsafe/wrong. This RUNS each
+ * dialog type and asserts the per-type accept flag — accept-all fails the
+ * confirm/prompt cases, dismiss-all fails beforeunload/alert.
+ *
+ * Run: node extension/test/dialog-autohandle.test.mjs
+ */
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+let passed = 0, failed = 0
+const test = (n, f) => { try { f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${n}`) } catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${n}\n    ${e.message}`) } }
+
+function extractAsyncFn(src, name) {
+  const marker = `async function ${name}(`
+  const start = src.indexOf(marker)
+  if (start === -1) throw new Error(`${marker}…) not found`)
+  const bodyStart = src.indexOf('{', start)
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) { const c = src[i]; if (c === '{') depth++; else if (c === '}') { depth--; if (!depth) { i++; break } } }
+  return src.slice(start, i)
+}
+
+const fnSrc = (() => { try { return extractAsyncFn(BG, 'handleDialogEvent') } catch { return null } })()
+
+function buildHandler() {
+  const calls = []
+  const chrome = { debugger: { sendCommand: async (target, method, params) => { calls.push({ target, method, params }); return {} } } }
+  const handler = new Function('chrome', `${fnSrc}\nreturn handleDialogEvent`)(chrome)
+  return { handler, calls }
+}
+
+console.log('\n  -- native dialogs auto-handled at CDP layer (never hang an op) --\n')
+
+test('handleDialogEvent exists as a named handler', () =>
+  assert(fnSrc, 'background.js must define `async function handleDialogEvent(source, method, params)`'))
+
+// NOTE: handleDialogEvent is async, but it invokes chrome.debugger.sendCommand
+// SYNCHRONOUSLY (the call expression runs before `await` suspends), so `calls`
+// is populated before handler(...) returns its promise — assert synchronously.
+test('ignores non-dialog events (no handleJavaScriptDialog call)', () => {
+  assert(fnSrc, 'handler missing')
+  const { handler, calls } = buildHandler()
+  handler({ tabId: 1 }, 'Network.requestWillBeSent', {})
+  assert.equal(calls.length, 0, 'must not act on non-dialog CDP events')
+})
+
+for (const [type, accept] of [['beforeunload', true], ['alert', true], ['confirm', false], ['prompt', false]]) {
+  test(`${type} → handleJavaScriptDialog accept:${accept}`, () => {
+    assert(fnSrc, 'handler missing')
+    const { handler, calls } = buildHandler()
+    handler({ tabId: 7 }, 'Page.javascriptDialogOpening', { type })
+    assert.equal(calls.length, 1, 'must handle the dialog exactly once')
+    assert.equal(calls[0].method, 'Page.handleJavaScriptDialog')
+    assert.equal(calls[0].target.tabId, 7, 'must target the source tab')
+    assert.equal(calls[0].params.accept, accept, `${type} accept policy`)
+  })
+}
+
+test('handler is registered AND Page is enabled on debugger attach (wiring)', () => {
+  assert(BG.includes('chrome.debugger.onEvent.addListener(handleDialogEvent)'),
+    'handleDialogEvent must be registered as a debugger event listener')
+  const ed = BG.slice(BG.indexOf('async function ensureDebugger('), BG.indexOf('async function withDebugger('))
+  assert(ed.includes("'Page.enable'"),
+    'ensureDebugger must enable the Page domain so Page.javascriptDialogOpening is delivered')
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)

--- a/extension/test/frame-piercing.test.mjs
+++ b/extension/test/frame-piercing.test.mjs
@@ -88,7 +88,7 @@ test('selector-bearing handlers route through resolveFrame', () => {
 })
 
 test('CDP coordinate ops translate frame-relative coords (dx/dy)', () => {
-  const click = slice("case 'click': {", 2200)
+  const click = slice("case 'click': {", 3200) // window widened for the visible-match clickResolver (2026-06-11)
   assert(click.includes('result.x + dx'), 'trusted click must offset by iframe viewport position')
   const hover = slice("case 'hover': {", 800)
   assert(hover.includes('coords.x + dx'), 'hover mouseMoved must offset by iframe viewport position')

--- a/extension/test/ime-composition.test.mjs
+++ b/extension/test/ime-composition.test.mjs
@@ -1,23 +1,21 @@
 /**
- * Constraint: op:input type/fill into a contenteditable drives the TRUSTED IME
- * composition pipeline (Input.imeSetComposition → Input.insertText), not a bare
- * insertText — so editors that commit their MODEL only on composition events
- * (compositionstart/update/end), as Chinese IME rich editors do, actually sync.
- * Classification: correctness / what — RC1, 2026-06-12 weixin dogfood: WeChat
- *   msg-sender `.edit_area` kept an EMPTY model (确定 → "内容不能为空") even though
- *   insertText filled the DOM; op:input press (dispatchKeyEvent) no-op'd, blur
- *   didn't sync, and op:eval event-dispatch is lint-forbidden — leaving NO path
- *   to commit the editor's model. imeSetComposition produces the trusted
- *   compositionstart/update; the following insertText commits (compositionend +
- *   input). insertText stays the commit step → Quill/ProseMirror unaffected.
+ * Constraint: op:input type/fill into a contenteditable is EDITOR-AWARE.
+ *  - Custom editors that commit their MODEL only on compositionend (WeChat
+ *    msg-sender `.edit_area`) get the trusted IME pipeline: select-all →
+ *    insertText('') [clear] → imeSetComposition (compositionstart/update) →
+ *    insertText (commit: compositionend + input).
+ *  - Editors that handle Input.insertText natively (ProseMirror, Quill — issue
+ *    #19 — CodeMirror) DOUBLE-insert under a composition, so they get plain
+ *    select-all → insertText (single replace), NO composition.
+ * Classification: correctness / what — RC1 (2026-06-12 weixin dogfood). The
+ *   composition fix made `.edit_area` writable (counter 300→226) but doubled
+ *   ProseMirror (被关注: pmLen 197 ≈ 2×) — so composition must be opt-in for
+ *   editors not recognised as native-insert.
  *
  * Behavioral (extract-and-run): typeIntoContentEditable is pulled from
- * background.js source and executed with stubbed deps that RECORD the CDP command
- * order, so we assert the real call sequence — not a grep.
- *
- * Phase 1a (adversarial): a half-impl that greps "imeSetComposition" into a
- * comment, or calls it AFTER insertText, fails — this checks the recorded order
- * (compose THEN commit) and the params (full text, caret at end).
+ * background.js and executed with stubbed deps + a fake execFunc that runs the
+ * injected page-functions (the native-editor probe + the verify read) against a
+ * fake editor element, so we assert the real CDP command sequence per editor kind.
  *
  * Run: node extension/test/ime-composition.test.mjs
  */
@@ -39,13 +37,30 @@ function extractAsyncFn(src, name) {
 
 const fnSrc = extractAsyncFn(BG, 'typeIntoContentEditable')
 
-async function runType(text) {
+// Fake editor element supporting the probe (closest/classList) + verify (textContent).
+function makeEditorEl(kind, text) {
+  if (kind === 'prosemirror') {
+    return {
+      closest: (s) => /ProseMirror|ql-editor|CodeMirror|cm-editor/.test(s) ? {} : null,
+      classList: { contains: (c) => c === 'ProseMirror' },
+      textContent: text,
+    }
+  }
+  return { closest: () => null, classList: { contains: () => false }, textContent: text } // custom contenteditable
+}
+
+async function runType(text, kind = 'custom') {
   const cmds = []
   const chrome = { debugger: { sendCommand: async (_t, method, params) => { cmds.push({ method, params }); return {} } } }
   const cdpClick = async () => { cmds.push({ method: 'cdpClick' }) }
   const handleMethod = async () => { cmds.push({ method: 'selectAll' }) }
   const withDebugger = async (_tabId, f) => await f()
-  const execFunc = async () => text // verify-read returns the text → DOM check passes
+  const editorEl = makeEditorEl(kind, text)
+  const execFunc = async (_fx, pageFn, ...args) => {
+    const document = { querySelector: () => editorEl }
+    const bound = new Function('document', `return (${pageFn.toString()})`)(document)
+    return bound(...args)
+  }
   const factory = new Function('cdpClick', 'handleMethod', 'withDebugger', 'chrome', 'execFunc',
     `${fnSrc}\nreturn typeIntoContentEditable`)
   const fn = factory(cdpClick, handleMethod, withDebugger, chrome, execFunc)
@@ -53,49 +68,57 @@ async function runType(text) {
   return cmds
 }
 
+const has = (cmds, method) => cmds.some(c => c.method === method)
+
 async function test(name, f) {
   try { await f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`) }
   catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${name}\n    ${e.message}`) }
 }
 
 async function main() {
-  console.log('\n  -- RC1: contenteditable typing drives the trusted IME composition pipeline --\n')
+  console.log('\n  -- RC1: editor-aware contenteditable input (composition opt-in) --\n')
 
   await test('typeIntoContentEditable exists', () => assert(fnSrc, 'helper must exist'))
 
-  await test('non-empty text: imeSetComposition fires BEFORE insertText (compose → commit)', async () => {
-    const cmds = await runType('你好世界')
+  // ── custom editor (.edit_area): composition pipeline ──
+  await test('custom editor: clear selection → compose → commit, in order', async () => {
+    const cmds = await runType('你好世界', 'custom')
+    const inserts = cmds.map((c, i) => ({ ...c, i })).filter(c => c.method === 'Input.insertText')
+    const clear = inserts.find(c => c.params.text === '')
+    const commit = inserts.find(c => c.params.text === '你好世界')
     const ime = cmds.findIndex(c => c.method === 'Input.imeSetComposition')
-    const ins = cmds.findIndex(c => c.method === 'Input.insertText')
-    assert(ime !== -1, 'must call Input.imeSetComposition (fires compositionstart/update the model listens for)')
-    assert(ins !== -1, 'must still call Input.insertText (commit: compositionend + input)')
-    assert(ime < ins, 'imeSetComposition must PRECEDE insertText (compose, then commit)')
+    assert(clear, 'must insertText("") to DELETE the select-all selection (composition does not clear it)')
+    assert(ime !== -1, 'must call Input.imeSetComposition (the model listens for compositionstart/update)')
+    assert(commit, 'must call Input.insertText(full text) to commit')
+    assert(clear.i < ime, 'clear must precede composition')
+    assert(ime < commit.i, 'composition must precede the commit insertText')
   })
 
-  await test('imeSetComposition carries the full text with caret collapsed at end', async () => {
-    const cmds = await runType('你好世界')
-    const ime = cmds.find(c => c.method === 'Input.imeSetComposition')
-    assert.equal(ime.params.text, '你好世界', 'composition text must be the full string')
-    assert.equal(ime.params.selectionStart, 4, 'selectionStart at end')
-    assert.equal(ime.params.selectionEnd, 4, 'selectionEnd at end (collapsed caret)')
+  await test('custom editor: imeSetComposition carries full text, caret at end', async () => {
+    const ime = (await runType('你好世界', 'custom')).find(c => c.method === 'Input.imeSetComposition')
+    assert.equal(ime.params.text, '你好世界')
+    assert.equal(ime.params.selectionStart, 4)
+    assert.equal(ime.params.selectionEnd, 4)
   })
 
-  await test('insertText still commits the same text (composition-agnostic editors unaffected)', async () => {
-    const cmds = await runType('abc')
-    const ins = cmds.find(c => c.method === 'Input.insertText')
-    assert.equal(ins.params.text, 'abc')
+  await test('custom editor: empty text skips composition', async () => {
+    assert(!has(await runType('', 'custom'), 'Input.imeSetComposition'), 'empty insert must not open a composition')
   })
 
-  await test('empty text: skips composition (no imeSetComposition on a clear)', async () => {
-    const cmds = await runType('')
-    assert(!cmds.some(c => c.method === 'Input.imeSetComposition'), 'empty insert must not open a composition')
+  // ── native-insert editor (ProseMirror/Quill/CodeMirror): NO composition ──
+  await test('ProseMirror: NO composition, NO clear — plain select-all + insertText (single replace)', async () => {
+    const cmds = await runType('你好世界', 'prosemirror')
+    assert(!has(cmds, 'Input.imeSetComposition'), 'native-insert editors must NOT get a composition (would double-insert)')
+    const inserts = cmds.filter(c => c.method === 'Input.insertText')
+    assert(!inserts.some(c => c.params.text === ''), 'must NOT do the clear-selection insertText("") (insertText replaces natively)')
+    assert(inserts.length === 1 && inserts[0].params.text === '你好世界', 'exactly one insertText carrying the full text')
   })
 
-  await test('select-all precedes composition (replaces existing content)', async () => {
-    const cmds = await runType('xy')
+  await test('ProseMirror: select-all still runs before the insert (replace existing content)', async () => {
+    const cmds = await runType('xy', 'prosemirror')
     const sel = cmds.findIndex(c => c.method === 'selectAll')
-    const ime = cmds.findIndex(c => c.method === 'Input.imeSetComposition')
-    assert(sel !== -1 && sel < ime, 'select-all must run before composition so it replaces existing content')
+    const ins = cmds.findIndex(c => c.method === 'Input.insertText')
+    assert(sel !== -1 && sel < ins, 'select-all must precede insertText so it replaces existing content')
   })
 
   console.log(`\n  ${passed} passed, ${failed} failed\n`)

--- a/extension/test/ime-composition.test.mjs
+++ b/extension/test/ime-composition.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * Constraint: op:input type/fill into a contenteditable drives the TRUSTED IME
+ * composition pipeline (Input.imeSetComposition → Input.insertText), not a bare
+ * insertText — so editors that commit their MODEL only on composition events
+ * (compositionstart/update/end), as Chinese IME rich editors do, actually sync.
+ * Classification: correctness / what — RC1, 2026-06-12 weixin dogfood: WeChat
+ *   msg-sender `.edit_area` kept an EMPTY model (确定 → "内容不能为空") even though
+ *   insertText filled the DOM; op:input press (dispatchKeyEvent) no-op'd, blur
+ *   didn't sync, and op:eval event-dispatch is lint-forbidden — leaving NO path
+ *   to commit the editor's model. imeSetComposition produces the trusted
+ *   compositionstart/update; the following insertText commits (compositionend +
+ *   input). insertText stays the commit step → Quill/ProseMirror unaffected.
+ *
+ * Behavioral (extract-and-run): typeIntoContentEditable is pulled from
+ * background.js source and executed with stubbed deps that RECORD the CDP command
+ * order, so we assert the real call sequence — not a grep.
+ *
+ * Phase 1a (adversarial): a half-impl that greps "imeSetComposition" into a
+ * comment, or calls it AFTER insertText, fails — this checks the recorded order
+ * (compose THEN commit) and the params (full text, caret at end).
+ *
+ * Run: node extension/test/ime-composition.test.mjs
+ */
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+let passed = 0, failed = 0
+
+function extractAsyncFn(src, name) {
+  const marker = `async function ${name}(`
+  const start = src.indexOf(marker)
+  if (start === -1) return null
+  const bodyStart = src.indexOf('{', start)
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) { const c = src[i]; if (c === '{') depth++; else if (c === '}') { depth--; if (!depth) { i++; break } } }
+  return src.slice(start, i)
+}
+
+const fnSrc = extractAsyncFn(BG, 'typeIntoContentEditable')
+
+async function runType(text) {
+  const cmds = []
+  const chrome = { debugger: { sendCommand: async (_t, method, params) => { cmds.push({ method, params }); return {} } } }
+  const cdpClick = async () => { cmds.push({ method: 'cdpClick' }) }
+  const handleMethod = async () => { cmds.push({ method: 'selectAll' }) }
+  const withDebugger = async (_tabId, f) => await f()
+  const execFunc = async () => text // verify-read returns the text → DOM check passes
+  const factory = new Function('cdpClick', 'handleMethod', 'withDebugger', 'chrome', 'execFunc',
+    `${fnSrc}\nreturn typeIntoContentEditable`)
+  const fn = factory(cdpClick, handleMethod, withDebugger, chrome, execFunc)
+  await fn(1, null, '.edit_area', text, { x: 10, y: 10 })
+  return cmds
+}
+
+async function test(name, f) {
+  try { await f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`) }
+  catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${name}\n    ${e.message}`) }
+}
+
+async function main() {
+  console.log('\n  -- RC1: contenteditable typing drives the trusted IME composition pipeline --\n')
+
+  await test('typeIntoContentEditable exists', () => assert(fnSrc, 'helper must exist'))
+
+  await test('non-empty text: imeSetComposition fires BEFORE insertText (compose → commit)', async () => {
+    const cmds = await runType('你好世界')
+    const ime = cmds.findIndex(c => c.method === 'Input.imeSetComposition')
+    const ins = cmds.findIndex(c => c.method === 'Input.insertText')
+    assert(ime !== -1, 'must call Input.imeSetComposition (fires compositionstart/update the model listens for)')
+    assert(ins !== -1, 'must still call Input.insertText (commit: compositionend + input)')
+    assert(ime < ins, 'imeSetComposition must PRECEDE insertText (compose, then commit)')
+  })
+
+  await test('imeSetComposition carries the full text with caret collapsed at end', async () => {
+    const cmds = await runType('你好世界')
+    const ime = cmds.find(c => c.method === 'Input.imeSetComposition')
+    assert.equal(ime.params.text, '你好世界', 'composition text must be the full string')
+    assert.equal(ime.params.selectionStart, 4, 'selectionStart at end')
+    assert.equal(ime.params.selectionEnd, 4, 'selectionEnd at end (collapsed caret)')
+  })
+
+  await test('insertText still commits the same text (composition-agnostic editors unaffected)', async () => {
+    const cmds = await runType('abc')
+    const ins = cmds.find(c => c.method === 'Input.insertText')
+    assert.equal(ins.params.text, 'abc')
+  })
+
+  await test('empty text: skips composition (no imeSetComposition on a clear)', async () => {
+    const cmds = await runType('')
+    assert(!cmds.some(c => c.method === 'Input.imeSetComposition'), 'empty insert must not open a composition')
+  })
+
+  await test('select-all precedes composition (replaces existing content)', async () => {
+    const cmds = await runType('xy')
+    const sel = cmds.findIndex(c => c.method === 'selectAll')
+    const ime = cmds.findIndex(c => c.method === 'Input.imeSetComposition')
+    assert(sel !== -1 && sel < ime, 'select-all must run before composition so it replaces existing content')
+  })
+
+  console.log(`\n  ${passed} passed, ${failed} failed\n`)
+  process.exit(failed ? 1 : 0)
+}
+main()

--- a/extension/test/keys-noop-verify.test.mjs
+++ b/extension/test/keys-noop-verify.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Constraint: op:input type's `keys` fallback (per-char CDP dispatchKeyEvent)
+ * MUST verify the text landed when the target is an editor context — a silent
+ * no-op there is a failure, not a success.
+ * Classification: correctness+safety / what — 2026-06-11 weixin dogfood: typing
+ *   into `.emotion_editor` (被关注回复 composer — a non-isContentEditable host)
+ *   fell into the `keys` path; per-char dispatchKeyEvent({text}) no-op'd (issue
+ *   #19's lesson) and, UNLIKE the contenteditable path, the keys path had no
+ *   post-verify — so it returned success with zero text landed. Cost: 6 attempts
+ *   chasing a silent no-op that should have surfaced as one input_ineffective.
+ *
+ * Behavioral (extract-and-run, like visible-click / keytype-verify): the keys
+ * path's landed-check is pulled from background.js source as a named injected fn
+ * `const keysLanded = (s, want) => {…}` and executed against DOM doubles.
+ *
+ * Phase 1a (adversarial): a half-impl that just greps innerText, or that throws
+ * UNCONDITIONALLY on the keys path, fails here. The gate is the point: it must
+ * report editorish=true,has=false for the .emotion_editor shape (→ handler
+ * throws) but NOT false-fail a pure key-LISTENER widget (no contenteditable
+ * anywhere — the reason the keys path exists). This RUNS both shapes.
+ *
+ * Phase 1b (anchor): the real shape is a div host (isContentEditable=false) whose
+ * editable lives in/near a [contenteditable] descendant, innerText empty after a
+ * no-op type — the weixin .emotion_editor captured 2026-06-11.
+ *
+ * Run: node extension/test/keys-noop-verify.test.mjs
+ */
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+let passed = 0, failed = 0
+const test = (n, f) => { try { f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${n}`) } catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${n}\n    ${e.message}`) } }
+
+function extractFn(src, marker, argsig) {
+  const start = src.indexOf(marker)
+  if (start === -1) throw new Error(`${marker.trim()} not found`)
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start))
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) { const c = src[i]; if (c === '{') depth++; else if (c === '}') { depth--; if (!depth) { i++; break } } }
+  return src.slice(src.indexOf(argsig, start), i)
+}
+
+const fnSrc = (() => { try { return extractFn(BG, 'const keysLanded = ', '(s,') } catch { return null } })()
+
+const run = (src, doc) => new Function('document', `return (${src})`)(doc)
+const docWith = (el) => ({ querySelector: () => el })
+
+console.log('\n  -- op:input type keys-path verifies it landed (editor-gated) --\n')
+
+test('keysLanded exists as a named injected fn', () =>
+  assert(fnSrc, 'type keys-path must define `const keysLanded = (s, want) => {…}` (named so it injects AND is testable)'))
+
+test('editor host (contenteditable descendant), text did NOT land → editorish:true, has:false (handler must throw)', () => {
+  assert(fnSrc, 'keysLanded missing')
+  const editorHost = {
+    isContentEditable: false,
+    innerText: '', textContent: '',
+    querySelector: (q) => (/contenteditable/.test(q) ? { tag: 'DIV' } : null),
+    closest: () => null,
+  }
+  const r = run(fnSrc, docWith(editorHost))('.emotion_editor', '欢迎关注')
+  assert.equal(r.found, true)
+  assert.equal(r.editorish, true, 'a host with a [contenteditable] descendant is an editor context')
+  assert.equal(r.has, false, 'empty editor after a no-op type must report has:false')
+})
+
+test('editor host, text DID land → has:true (no throw)', () => {
+  assert(fnSrc, 'keysLanded missing')
+  const editorHost = {
+    isContentEditable: false,
+    innerText: '欢迎关注 这个号做核查报告', textContent: '欢迎关注 这个号做核查报告',
+    querySelector: (q) => (/contenteditable/.test(q) ? { tag: 'DIV' } : null),
+    closest: () => null,
+  }
+  const r = run(fnSrc, docWith(editorHost))('.emotion_editor', '欢迎关注')
+  assert.equal(r.has, true, 'landed text (whitespace-insensitive) must report has:true')
+})
+
+test('pure key-LISTENER widget (no contenteditable anywhere) → editorish:false (NEVER false-fails)', () => {
+  assert(fnSrc, 'keysLanded missing')
+  const listener = { isContentEditable: false, innerText: '', textContent: '', querySelector: () => null, closest: () => null }
+  const r = run(fnSrc, docWith(listener))('.hotkey-capture', 'abc')
+  assert.equal(r.editorish, false, 'no contenteditable in/around it → not an editor → keys path stays silent (no regression)')
+})
+
+test('handler throws input_ineffective when found && editorish && !has (wiring)', () => {
+  const i = BG.indexOf("} else if (probe.mode === 'keys') {")
+  assert(i !== -1, "keys branch present")
+  const branch = BG.slice(i, i + 2200) // window covers the comment + keysLanded fn + throw
+  assert(branch.includes('keysLanded'), 'keys branch must call keysLanded after typing')
+  assert(branch.includes('editorish') && branch.includes('input_ineffective'),
+    'keys branch must throw input_ineffective when an editor-context type landed nothing')
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)

--- a/extension/test/keytype-verify.test.mjs
+++ b/extension/test/keytype-verify.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * Constraint: op:input keytype verifies the typed text landed in a CONTENTEDITABLE
+ * by reading innerText/textContent — not `.value` (which is undefined on a
+ * contenteditable <div>, yielding a false "value did not land" error).
+ * Classification: correctness / what — 2026-06-11 weixin dogfood: keytype into a
+ *   contenteditable threw `keytype: value did not land (got len 0)` even though
+ *   Input.insertText placed the text (text was in .innerText, verifier read .value).
+ *
+ * Behavioral (extract-and-run, like visible-click.test.mjs): the keytype
+ * post-verify read is extracted from background.js source and executed against a
+ * DOM double whose element is contenteditable (isContentEditable:true,
+ * innerText set, value:undefined).
+ *
+ * Phase 1a (adversarial): a half-impl that keeps `el.value || ''` passes any
+ * grep mentioning innerText elsewhere. This RUNS the verifier read against a
+ * contenteditable double and asserts it returns the text — the `.value`-only
+ * impl returns '' and fails. And asserts a plain <input> still reads `.value`
+ * (no regression to the rc-field-form case keytype exists for).
+ *
+ * Run: node extension/test/keytype-verify.test.mjs
+ */
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+let passed = 0, failed = 0
+const test = (n, f) => { try { f(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${n}`) } catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${n}\n    ${e.message}`) } }
+
+// Extract `const readControlValue = (s) => { ... }` (GREEN names the keytype verifier read).
+function extractReader(src) {
+  const marker = 'const readControlValue = '
+  const start = src.indexOf(marker)
+  if (start === -1) throw new Error('readControlValue not found — keytype must name its verify-read `const readControlValue = (s) => {…}`')
+  const bodyStart = src.indexOf('{', src.indexOf('=>', start))
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) { const c = src[i]; if (c === '{') depth++; else if (c === '}') { depth--; if (!depth) { i++; break } } }
+  return src.slice(src.indexOf('(s)', start), i)
+}
+
+const readerSrc = (() => { try { return extractReader(BG) } catch { return null } })()
+
+console.log('\n  -- keytype verify-read is contenteditable-aware --\n')
+
+test('readControlValue exists as a named injected fn', () => assert(readerSrc, 'keytype must define `const readControlValue = (s) => {…}`'))
+
+test('contenteditable (value:undefined, innerText set) → reads innerText', () => {
+  assert(readerSrc, 'reader missing')
+  const ce = { isContentEditable: true, value: undefined, innerText: '你好世界', textContent: '你好世界' }
+  const doc = { querySelector: () => ce }
+  const fn = new Function('document', `return (${readerSrc})`)(doc)
+  const got = fn('.edit_area')
+  assert.equal((got || '').replace(/\s+/g, ''), '你好世界', `contenteditable read must return its text, got ${JSON.stringify(got)}`)
+})
+
+test('plain <input> still reads .value (no regression)', () => {
+  assert(readerSrc, 'reader missing')
+  const inp = { isContentEditable: false, value: 'abc123', innerText: '', textContent: '' }
+  const fn = new Function('document', `return (${readerSrc})`)({ querySelector: () => inp })
+  assert.equal(fn('#x'), 'abc123', 'plain input must still read .value')
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)

--- a/extension/test/visible-click.test.mjs
+++ b/extension/test/visible-click.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Constraint: op:input click resolves to a VISIBLE/interactable element.
+ * Classification: safety / what — violations destroy state (clicked a hidden
+ * "退出登录" in the 2026-06-11 weixin menu dogfood → logged the session out).
+ *
+ * This is BEHAVIORAL, not structural: it extracts the click handler's injected
+ * page-function from background.js source and executes it against a DOM double
+ * where document.querySelector(sel)'s FIRST match is hidden (display:none) and
+ * a later match is visible. The constraint: the visible element is the one that
+ * receives .click().
+ *
+ * Phase 1a (adversarial): a half-impl that adds a visibility helper but still
+ * clicks `document.querySelector(t)` (first match) would pass any grep for
+ * "getComputedStyle". This test catches that shortcut because it RUNS the real
+ * source against a DOM where first-match===hidden and asserts the *visible*
+ * node was clicked — a first-match impl returns the hidden node and fails.
+ *
+ * Phase 1b (anchor): the DOM shape (hidden primary button preceding a visible
+ * one sharing a class) is the exact real shape from the weixin self-menu editor
+ * (`.weui-desktop-btn_primary` first match = hidden 退出登录, second = visible
+ * 保存并发布) captured 2026-06-11.
+ *
+ * Run: node extension/test/visible-click.test.mjs
+ */
+
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG_SRC = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+
+let passed = 0, failed = 0
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`) }
+  catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${name}`); console.log(`    ${e.message}`) }
+}
+
+// --- Extract the named click resolver injected into the page (GREEN adds it). ---
+// Marker contract: `const clickResolver = (t) => { ... }` inside the click case.
+function extractClickResolver(src) {
+  const marker = 'const clickResolver = '
+  const start = src.indexOf(marker)
+  if (start === -1) throw new Error('clickResolver not found — click handler must define a named, self-contained `const clickResolver = (t) => {…}` resolver (so it injects AND is testable)')
+  // brace-match from the arrow body
+  const arrowBodyStart = src.indexOf('{', start)
+  let depth = 0, i = arrowBodyStart
+  for (; i < src.length; i++) {
+    const c = src[i]
+    if (c === '{') depth++
+    else if (c === '}') { depth--; if (depth === 0) { i++; break } }
+  }
+  const fnSrc = src.slice(src.indexOf('(t)', start), i) // (t) => { ... }
+  return fnSrc
+}
+
+// --- Minimal DOM double ---
+function makeEl(id, { display = 'block', w = 40, h = 20, text = '', aria = '' } = {}) {
+  return {
+    __id: id, __clicked: false, __display: display,
+    textContent: text, children: [],
+    getAttribute: (k) => (k === 'aria-label' ? aria : null),
+    scrollIntoView() {},
+    click() { this.__clicked = true },
+    getBoundingClientRect() { return { x: 0, y: 0, width: w, height: h } },
+  }
+}
+
+console.log('\n  -- op:input click prefers the visible match --\n')
+
+const resolverSrc = (() => { try { return extractClickResolver(BG_SRC) } catch (e) { return null } })()
+
+test('clickResolver exists as a self-contained named injected fn', () => {
+  assert(resolverSrc, 'background.js must define `const clickResolver = (t) => {…}`')
+})
+
+test('first match hidden, second visible → clicks the VISIBLE one', () => {
+  assert(resolverSrc, 'resolver missing (see prior failure)')
+  const hidden = makeEl('hidden', { display: 'none' })   // querySelector first match
+  const visible = makeEl('visible', { display: 'block' }) // later sibling, same selector
+  const all = [hidden, visible]
+  const fakeDoc = {
+    body: {},
+    querySelector: () => all[0],
+    querySelectorAll: () => all,
+    createTreeWalker: () => ({ nextNode: () => null }),
+  }
+  const fakeGetStyle = (el) => ({ display: el.__display, visibility: 'visible', opacity: '1' })
+  const NodeFilterStub = { SHOW_ELEMENT: 1 }
+  const factory = new Function('document', 'getComputedStyle', 'NodeFilter', `return (${resolverSrc})`)
+  const resolver = factory(fakeDoc, fakeGetStyle, NodeFilterStub)
+  resolver('.weui-desktop-btn_primary')
+  assert(!hidden.__clicked, 'must NOT click the hidden first match (the 退出登录 footgun)')
+  assert(visible.__clicked, 'must click the visible match')
+})
+
+test('single visible match → unchanged behavior (clicks it)', () => {
+  assert(resolverSrc, 'resolver missing')
+  const only = makeEl('only', { display: 'block' })
+  const fakeDoc = { body: {}, querySelector: () => only, querySelectorAll: () => [only], createTreeWalker: () => ({ nextNode: () => null }) }
+  const factory = new Function('document', 'getComputedStyle', 'NodeFilter', `return (${resolverSrc})`)
+  factory(fakeDoc, (el) => ({ display: el.__display, visibility: 'visible', opacity: '1' }), { SHOW_ELEMENT: 1 })('.x')
+  assert(only.__clicked, 'single visible match must still be clicked')
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+process.exit(failed ? 1 : 0)


### PR DESCRIPTION
## What

Engine fixes surfaced by a dogfood automating the WeChat 公众号 backend — a token-gated, framework-reactive authenticated SPA (custom-menu API + keyword / subscribe auto-replies). Each is anchored to a **specific observed failure**, behaviorally tested, and **live-verified against the real WeChat msg-sender before commit**.

## Fixes

**`041db73` — op:input + native-dialog hardening**
- **P0a** click resolves to the *visible* match (a hidden first `.weui-desktop-btn_primary` = 退出登录 got clicked → logged the session out)
- **P0b** op:nav neutralizes a dirty page's `beforeunload` before a same-origin `tabs.update` (was hanging ~3.5min)
- **P0c** op:input type's per-char `keys` fallback verifies the text landed (editor-gated) — a silent no-op becomes a loud `input_ineffective`
- **P0d** native dialogs auto-handled at the CDP layer (`Page.javascriptDialogOpening` → accept beforeunload/alert, dismiss confirm/prompt) so no op hangs on one
- **P1b** keytype verifies via `innerText` on a contenteditable (was a false "value did not land")

**`4bae6d0` — RC1 IME-composition input + P0b real bug**
- Custom contenteditables (WeChat `.edit_area`) commit their MODEL only on `compositionend`, not on the `input` event a bare `Input.insertText` fires (确定 → "内容不能为空" though the DOM was filled). Drive the trusted IME pipeline `imeSetComposition` → `insertText`. **Verified: editor char counter 300→226 for a 74-char insert = model synced.**
- Fixed P0b's real bug: the beforeunload suppressor called `e.preventDefault()` — which on a `beforeunload` event *requests* the dialog (HTML spec), so it popped the very "Leave site?" it exists to kill. **Verified: dirty reload now ~5s (was ~3.5min).**

**`e88166a` — RC1 editor-aware (composition opt-in)**
- RC1-for-all silently regressed every native-insert editor (ProseMirror, Quill — issue #19 — CodeMirror): they DOUBLE-insert under a composition. Composition is now opt-IN — known frameworks use plain select-all + insertText (single replace); custom editors keep the IME pipeline. **Verified on `.ProseMirror` (被关注): single clean full replace, saved + confirmed on fresh reload.**

## Tests

18 extension test files green. New behavioral suites extract the injected page-function from `background.js` source and run it against captured DOM / CDP shapes: `visible-click`, `beforeunload-suppress`, `keys-noop-verify`, `dialog-autohandle`, `keytype-verify`, `ime-composition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)