### PR TITLE
fix(extension): eval_error wire kind + cdpClick mouseMoved lead-in; surface trusted in spec schema (#65, #66)

### DIFF
--- a/docs/spec/plan-v1.schema.json
+++ b/docs/spec/plan-v1.schema.json
@@ -129,6 +129,10 @@
         "kind": { "enum": ["click", "type", "fill", "press", "upload", "setHtml", "hover", "keytype", "blur"] },
         "target": { "type": "string" },
         "value": { "type": "string" },
+        "trusted": {
+          "type": "boolean",
+          "description": "Substrate-tier hint. Absent/false (default) → L1: JS-injection el.click() — isTrusted:false, CSP-immune, no DevTools bar. true → L2: CDP-dispatched mouse events at element coordinates (isTrusted:true). L2 is REQUIRED to activate gesture-bound framework buttons (Polymer/Wiz tap recognizers — e.g. YouTube Studio ytcp-button, Material ripple buttons) that ignore a synthetic JS click. Set by capture when forge detects L1 fails the expect predicate; authors may set it directly when a click silently no-ops on a framework button."
+        },
         "save": { "type": "string" }
       }
     },

--- a/docs/spec/plan-v1/schema.json
+++ b/docs/spec/plan-v1/schema.json
@@ -129,6 +129,10 @@
         "kind": { "enum": ["click", "type", "fill", "press", "upload", "setHtml", "hover", "keytype", "blur"] },
         "target": { "type": "string" },
         "value": { "type": "string" },
+        "trusted": {
+          "type": "boolean",
+          "description": "Substrate-tier hint. Absent/false (default) → L1: JS-injection el.click() — isTrusted:false, CSP-immune, no DevTools bar. true → L2: CDP-dispatched mouse events at element coordinates (isTrusted:true). L2 is REQUIRED to activate gesture-bound framework buttons (Polymer/Wiz tap recognizers — e.g. YouTube Studio ytcp-button, Material ripple buttons) that ignore a synthetic JS click. Set by capture when forge detects L1 fails the expect predicate; authors may set it directly when a click silently no-ops on a framework button."
+        },
         "save": { "type": "string" }
       }
     },

--- a/extension/background.js
+++ b/extension/background.js
@@ -169,13 +169,20 @@ async function withDebugger(tabId, fn) {
   finally { scheduleDetach(tabId) }
 }
 
+// mouseMoved precedes press so hover/ripple-gated gesture recognizers
+// (Polymer/Wiz `tap` — YouTube Studio ytcp-button; Material ripple) see the
+// pointer enter the element first; a bare press/release at coords they never
+// saw move to silently no-ops (#65 YouTube Studio edit-button dogfood).
 async function cdpClick(tabId, x, y) {
   await withDebugger(tabId, async () => {
     await chrome.debugger.sendCommand({ tabId }, 'Input.dispatchMouseEvent', {
-      type: 'mousePressed', x, y, button: 'left', clickCount: 1
+      type: 'mouseMoved', x, y, button: 'none', buttons: 0
     })
     await chrome.debugger.sendCommand({ tabId }, 'Input.dispatchMouseEvent', {
-      type: 'mouseReleased', x, y, button: 'left', clickCount: 1
+      type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1
+    })
+    await chrome.debugger.sendCommand({ tabId }, 'Input.dispatchMouseEvent', {
+      type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1
     })
   })
 }
@@ -2019,6 +2026,11 @@ const WIRE_CODE = {
   timeout: -32012,
   wire_kind_unknown: -32013,
   tap_drifted: -32014,
+  // -32016: op:eval page-context JS exception (tap-core#65). Op-level abort
+  // (the page threw), NOT peer-transport — keeps it off the misleading
+  // reconnect_extension recovery hint. Mirrors core/core/wire-codes.ts; W4
+  // drift-guard keeps them in lockstep.
+  eval_error: -32016,
 }
 
 const NATIVE_HOST_NAME = 'dev.taprun.daemon'
@@ -2200,7 +2212,7 @@ function connectBridge() {
 // Classify extension-side error string into a JSON-RPC code via
 // WIRE_CODE. Covers the common cases the SW's handleMethod can throw;
 // unknown shapes default to peer_unreachable (back-compat).
-function classifyExtensionError(msg, _method) {
+function classifyExtensionError(msg, method) {
   const s = String(msg || '').toLowerCase()
   if (s.includes('http_error') || /\bstatus[:=]\s*[45]\d\d/.test(s)) {
     return WIRE_CODE.fetch_http
@@ -2222,6 +2234,16 @@ function classifyExtensionError(msg, _method) {
   }
   if (s.includes('permission')) {
     return WIRE_CODE.permission_denied
+  }
+  // op:eval page-context exceptions (a throw inside the fn — TypeError,
+  // ReferenceError, a bad-shape return, …) RAN on the substrate and the PAGE
+  // threw: an op-level abort, not the peer being unreachable. Pre-#65 these
+  // fell through to peer_unreachable below and mis-routed to the misleading
+  // reconnect_extension recovery hint, burying the real script bug. Gated on
+  // method==='eval' so a stray "TypeError: Failed to fetch" from another op
+  // is not swept up here. (tap-core#65)
+  if (method === 'eval') {
+    return WIRE_CODE.eval_error
   }
   return WIRE_CODE.peer_unreachable
 }

--- a/extension/test/classify-extension-error.test.mjs
+++ b/extension/test/classify-extension-error.test.mjs
@@ -1,0 +1,78 @@
+/**
+ * tap-core#65 — classifyExtensionError routes op:eval page exceptions to
+ * eval_error, NOT the peer_unreachable default.
+ *
+ * Why behavioral (extract + run): a grep for "eval_error" would pass a
+ * half-impl that put the branch AFTER the `return peer_unreachable` (dead
+ * code). This extracts the real function from background.js, injects the
+ * WIRE_CODE table it closes over, and runs it against representative inputs.
+ *
+ * Constraint: a JS exception surfaced by op:eval (method === 'eval') must
+ * map to WIRE_CODE.eval_error; the same message under a non-eval method must
+ * still fall through to peer_unreachable (the eval carve-out is method-gated,
+ * so a stray "TypeError: Failed to fetch" from another op is not swept up).
+ *
+ * Run: node extension/test/classify-extension-error.test.mjs
+ */
+
+import { strict as assert } from 'node:assert'
+import { readFileSync } from 'node:fs'
+
+const BG_SRC = readFileSync(new URL('../background.js', import.meta.url), 'utf-8')
+
+let passed = 0, failed = 0
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  \x1b[32m✓\x1b[0m ${name}`) }
+  catch (e) { failed++; console.log(`  \x1b[31m✗\x1b[0m ${name}`); console.log(`    ${e.message}`) }
+}
+
+// --- Extract the WIRE_CODE table + classifyExtensionError and build a runnable copy ---
+function buildClassifier(src) {
+  const wireMatch = src.match(/const WIRE_CODE = (\{[\s\S]*?\n\})/)
+  assert(wireMatch, 'background.js must declare const WIRE_CODE = {...}')
+  const fnStart = src.indexOf('function classifyExtensionError(')
+  assert(fnStart !== -1, 'classifyExtensionError must exist')
+  // brace-match the function body
+  const bodyStart = src.indexOf('{', fnStart)
+  let depth = 0, i = bodyStart
+  for (; i < src.length; i++) {
+    const c = src[i]
+    if (c === '{') depth++
+    else if (c === '}') { depth--; if (depth === 0) { i++; break } }
+  }
+  const fnSrc = src.slice(fnStart, i)
+  // eslint-disable-next-line no-new-func
+  return new Function(`${wireMatch[0]}\n${fnSrc}\nreturn classifyExtensionError`)()
+}
+
+const classify = buildClassifier(BG_SRC)
+const WIRE = (() => {
+  const m = BG_SRC.match(/const WIRE_CODE = (\{[\s\S]*?\n\})/)
+  // eslint-disable-next-line no-new-func
+  return new Function(`return ${m[1]}`)()
+})()
+
+console.log('\n  -- tap-core#65 classifyExtensionError eval routing --\n')
+
+test('op:eval JS exception → eval_error (not peer_unreachable)', () => {
+  const code = classify("TypeError: Cannot read properties of undefined (reading 'x')", 'eval')
+  assert.equal(code, WIRE.eval_error,
+    `eval page exception must map to eval_error (${WIRE.eval_error}); got ${code}`)
+  assert.notEqual(code, WIRE.peer_unreachable,
+    'eval exception must NOT map to peer_unreachable (that mis-routes to reconnect_extension)')
+})
+
+test('same message under a non-eval method stays peer_unreachable (method-gated)', () => {
+  const code = classify('TypeError: Failed to fetch', 'nav')
+  assert.equal(code, WIRE.peer_unreachable,
+    'the eval carve-out must be method-gated, not message-only')
+})
+
+test('specific matches still win under method=eval (csp before eval fallback)', () => {
+  const code = classify('content security policy blocked', 'eval')
+  assert.equal(code, WIRE.csp_violation,
+    'a recognizable csp message must classify as csp_violation even under eval')
+})
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`)
+if (failed > 0) process.exit(1)

--- a/extension/test/kernel-behavior.test.mjs
+++ b/extension/test/kernel-behavior.test.mjs
@@ -32,7 +32,9 @@ function test(name, fn) {
 // ═══════════════════════════════════════════════════════════
 // Rule 1: CDP Click Event Chain
 // Why: React and other frameworks need mousePressed + mouseReleased
-// as a pair. Missing either means the click never registers.
+// as a pair. Missing either means the click never registers. Plus a
+// mouseMoved lead-in so hover/ripple-gated gesture recognizers
+// (Polymer/Wiz tap) see the pointer enter before the press (tap-core#65).
 // ═══════════════════════════════════════════════════════════
 
 console.log('\n  -- Rule 1: CDP Click Event Chain --\n')
@@ -41,7 +43,7 @@ console.log('\n  -- Rule 1: CDP Click Event Chain --\n')
   const cdpClickStart = BG_SRC.indexOf('async function cdpClick(')
   assert(cdpClickStart !== -1, 'cdpClick function must exist')
   // Find the end of cdpClick by locating the next top-level function or section
-  const cdpClickBody = BG_SRC.substring(cdpClickStart, cdpClickStart + 500)
+  const cdpClickBody = BG_SRC.substring(cdpClickStart, cdpClickStart + 700)
 
   test('cdpClick dispatches mousePressed', () => {
     assert(cdpClickBody.includes('mousePressed'),
@@ -51,6 +53,14 @@ console.log('\n  -- Rule 1: CDP Click Event Chain --\n')
   test('cdpClick dispatches mouseReleased', () => {
     assert(cdpClickBody.includes('mouseReleased'),
       'cdpClick must dispatch mouseReleased event')
+  })
+
+  test('mouseMoved leads the press (hover/ripple gate — tap-core#65)', () => {
+    const movedIdx = cdpClickBody.indexOf('mouseMoved')
+    const pressedIdx = cdpClickBody.indexOf('mousePressed')
+    assert(movedIdx !== -1, 'cdpClick must dispatch a mouseMoved lead-in')
+    assert(movedIdx < pressedIdx,
+      'mouseMoved must precede mousePressed so the pointer is over the target before the press')
   })
 
   test('mousePressed comes before mouseReleased', () => {

--- a/packages/spec/schemas/plan-v1.schema.json
+++ b/packages/spec/schemas/plan-v1.schema.json
@@ -129,6 +129,10 @@
         "kind": { "enum": ["click", "type", "fill", "press", "upload", "setHtml", "hover", "keytype", "blur"] },
         "target": { "type": "string" },
         "value": { "type": "string" },
+        "trusted": {
+          "type": "boolean",
+          "description": "Substrate-tier hint. Absent/false (default) → L1: JS-injection el.click() — isTrusted:false, CSP-immune, no DevTools bar. true → L2: CDP-dispatched mouse events at element coordinates (isTrusted:true). L2 is REQUIRED to activate gesture-bound framework buttons (Polymer/Wiz tap recognizers — e.g. YouTube Studio ytcp-button, Material ripple buttons) that ignore a synthetic JS click. Set by capture when forge detects L1 fails the expect predicate; authors may set it directly when a click silently no-ops on a framework button."
+        },
         "save": { "type": "string" }
       }
     },


### PR DESCRIPTION
## What

Extension + spec half of the #65/#66 fixes (pairs with `LeonTing1010/tap-core` PR #68).

### #65 — eval_error wire kind
`classifyExtensionError` defaulted `op:eval` page exceptions to `peer_unreachable`, mis-routing a page script bug to the `reconnect_extension` recovery hint. Add `eval_error` wire code (`-32016`, mirrors `core/wire-codes.ts`; W4 drift-guard keeps lockstep) and a **method-gated** branch mapping `op:eval` JS exceptions to it (so a stray "TypeError: Failed to fetch" from another op isn't swept up).

### #66 — cdpClick mouseMoved lead-in + spec schema
- `cdpClick` now dispatches `mouseMoved` before `mousePressed` so hover/ripple-gated gesture recognizers (Polymer/Wiz `tap` — YouTube Studio `ytcp-button`, Material ripple) see the pointer enter before the press; a bare press/release at coords they never saw move to silently no-ops.
- Surface `op:input.trusted` in the canonical `@taprun/spec` `plan-v1` schema (byte-identical to the core asset per MR6).

## Tests
- New `classify-extension-error.test.mjs` (eval routing, method-gated).
- `kernel-behavior.test.mjs` gains a `mouseMoved`-before-press assertion.
- W4 drift + full extension sweep: **19 files clean**.

## Note
The browser-side effect of `cdpClick`/`trusted` on a specific gesture button wasn't live-verified this session (dev MCP ran the installed binary). Verify after a rebuild + extension reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)