### PR TITLE
feat(extension): op:input kind:resolve — read-only probe for the resolve gate (Clause B click half)

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -762,6 +762,15 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
         switch (kind) {
           case 'click':
             return await handleMethod('click', { ...rest, target }, senderTabId, { fromDaemon })
+          case 'resolve':
+            // Read-only resolve probe (resolve-before-dispatch gate, Clause B
+            // click half): does `target` resolve via click's EXACT chain? Runs
+            // the resolver WITHOUT clicking and returns { resolved }. A distinct
+            // kind (not a flag) so OLD extensions reject it via the "Unknown
+            // op:input kind" default below — they never click during a probe
+            // (version-skew safe). Routed through the click handler in probe
+            // mode so the resolution chain has zero drift.
+            return await handleMethod('click', { ...rest, target, probe: true }, senderTabId, { fromDaemon })
           case 'type':
             return await handleMethod('type', { ...rest, selector: target, text: value }, senderTabId, { fromDaemon })
           case 'fill':
@@ -806,7 +815,7 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
       // JS-first: use el.click() via execFunc — no debugger, no yellow bar, CSP-immune
       // Named + self-contained so it injects via execFunc AND is extractable by
       // test/visible-click.test.mjs (background.js isn't node-importable — chrome.*).
-      const clickResolver = (t) => {
+      const clickResolver = (t, probe) => {
         // Prefer the first VISIBLE match. document.querySelector returns the first
         // DOM match even if display:none/hidden — which clicked a hidden "退出登录"
         // sharing .weui-desktop-btn_primary in the 2026-06-11 weixin self-menu
@@ -835,13 +844,22 @@ async function handleMethod(method, params = {}, senderTabId = null, { fromDaemo
             if (n.textContent?.trim().toLowerCase().includes(t.toLowerCase()) && n.children.length === 0) { el = n; break }
           }
         }
+        // Probe mode (Clause B click half): report whether the target resolves
+        // via THIS exact chain, WITHOUT clicking. Placed after the full chain so
+        // the probe reflects click's real semantics (incl. semantic fallback).
+        if (probe) {
+          if (!el) return { resolved: false }
+          const rb = el.getBoundingClientRect()
+          return { resolved: true, x: Math.round(rb.x + rb.width / 2), y: Math.round(rb.y + rb.height / 2) }
+        }
         if (!el) throw new Error('Element not found: ' + t)
         el.scrollIntoView({ block: 'center', behavior: 'instant' })
         el.click()
         const r = el.getBoundingClientRect()
         return { clicked: true, x: Math.round(r.x + r.width / 2), y: Math.round(r.y + r.height / 2) }
       }
-      const result = await execFunc(fx, clickResolver, target)
+      const result = await execFunc(fx, clickResolver, target, params.probe)
+      if (params.probe) return { resolved: !!(result && result.resolved) }
       if (!result) throw new Error('selector_not_found: ' + target + ' (page not ready — exec returned null)')
       // CDP fallback: if site needs isTrusted events, retry with cdpClick
       // (dx/dy translate frame-relative coords to top-frame viewport space)

--- a/extension/test/frame-piercing.test.mjs
+++ b/extension/test/frame-piercing.test.mjs
@@ -88,7 +88,7 @@ test('selector-bearing handlers route through resolveFrame', () => {
 })
 
 test('CDP coordinate ops translate frame-relative coords (dx/dy)', () => {
-  const click = slice("case 'click': {", 3200) // window widened for the visible-match clickResolver (2026-06-11)
+  const click = slice("case 'click': {", 3700) // widened: visible-match clickResolver (2026-06-11) + probe-mode branch (Clause B, 2026-06-17)
   assert(click.includes('result.x + dx'), 'trusted click must offset by iframe viewport position')
   const hover = slice("case 'hover': {", 800)
   assert(hover.includes('coords.x + dx'), 'hover mouseMoved must offset by iframe viewport position')

--- a/extension/test/visible-click.test.mjs
+++ b/extension/test/visible-click.test.mjs
@@ -48,7 +48,7 @@ function extractClickResolver(src) {
     if (c === '{') depth++
     else if (c === '}') { depth--; if (depth === 0) { i++; break } }
   }
-  const fnSrc = src.slice(src.indexOf('(t)', start), i) // (t) => { ... }
+  const fnSrc = src.slice(src.indexOf('(', start), i) // (t[, probe]) => { ... }
   return fnSrc
 }
 
@@ -99,6 +99,38 @@ test('single visible match → unchanged behavior (clicks it)', () => {
   const factory = new Function('document', 'getComputedStyle', 'NodeFilter', `return (${resolverSrc})`)
   factory(fakeDoc, (el) => ({ display: el.__display, visibility: 'visible', opacity: '1' }), { SHOW_ELEMENT: 1 })('.x')
   assert(only.__clicked, 'single visible match must still be clicked')
+})
+
+// --- probe mode (resolve-before-dispatch gate, Clause B click half) ---
+// clickResolver(t, true) resolves via click's EXACT chain (incl. the semantic
+// text/aria fallback op:wait lacks) but returns { resolved } WITHOUT clicking.
+console.log('\n  -- op:input click probe mode (resolve, do not click) --\n')
+
+test('probe mode resolves a semantic-text-only target WITHOUT clicking', () => {
+  assert(resolverSrc, 'resolver missing')
+  const btn = makeEl('btn', { display: 'block', text: '立即打卡' })
+  const fakeDoc = {
+    body: {},
+    querySelector: () => null,                                       // literal selector misses
+    querySelectorAll: (s) => (String(s).includes('button') ? [btn] : []), // semantic scan finds it
+    createTreeWalker: () => ({ nextNode: () => null }),
+  }
+  const factory = new Function('document', 'getComputedStyle', 'NodeFilter', `return (${resolverSrc})`)
+  const resolver = factory(fakeDoc, (el) => ({ display: el.__display, visibility: 'visible', opacity: '1' }), { SHOW_ELEMENT: 1 })
+  const out = resolver('立即打卡', true)
+  assert(out && out.resolved === true, 'probe must resolve the semantic target (got ' + JSON.stringify(out) + ')')
+  assert(!btn.__clicked, 'probe must NOT click')
+})
+
+test('probe mode on a miss returns {resolved:false} and does NOT throw', () => {
+  assert(resolverSrc, 'resolver missing')
+  const fakeDoc = { body: {}, querySelector: () => null, querySelectorAll: () => [], createTreeWalker: () => ({ nextNode: () => null }) }
+  const factory = new Function('document', 'getComputedStyle', 'NodeFilter', `return (${resolverSrc})`)
+  const resolver = factory(fakeDoc, () => ({ display: 'block', visibility: 'visible', opacity: '1' }), { SHOW_ELEMENT: 1 })
+  let out, threw = false
+  try { out = resolver('nope', true) } catch { threw = true }
+  assert(!threw, 'probe must not throw on miss')
+  assert(out && out.resolved === false, 'probe returns {resolved:false} on miss')
 })
 
 console.log(`\n  ${passed} passed, ${failed} failed\n`)


### PR DESCRIPTION
Adds `op:input kind:resolve`: runs click's exact resolution chain read-only, returns {resolved}, no click. Version-skew safe (old extensions reject the unknown kind without clicking). Consumer = core resolveFirstMutation (separate core PR). Full extension suite green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)